### PR TITLE
Add an issue template plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /log/mongrel_debug
 /plugins/*
 !/plugins/redmine_webhook
+!/plugins/redmine_issue_templates
 !/plugins/README
 /public/dispatch.*
 /public/plugin_assets/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "plugins/redmine_webhook"]
 	path = plugins/redmine_webhook
 	url = https://github.com/suer/redmine_webhook
+[submodule "plugins/redmine_issue_templates"]
+	path = plugins/redmine_issue_templates
+	url = https://github.com/dolphin-emu/redmine_issue_templates.git


### PR DESCRIPTION
This PR adds an issue template plugin (https://www.redmine.org/plugins/issue_templates) to the redmine plugins available in the dolphin bug tracker.

It offers various options like setting several templates for a project and having one as a default.

to finalize the installation, doing a db:migrate_plugins and restarting redmine (and then enabling it and creating templates) should be everything needed to have it available.
